### PR TITLE
Extract code to VCRMixin

### DIFF
--- a/vcr_unittest/__init__.py
+++ b/vcr_unittest/__init__.py
@@ -1,1 +1,1 @@
-from .testcase import VCRTestCase
+from .testcase import VCRMixin, VCRTestCase

--- a/vcr_unittest/testcase.py
+++ b/vcr_unittest/testcase.py
@@ -10,11 +10,12 @@ import vcr
 logger = logging.getLogger(__name__)
 
 
-class VCRTestCase(unittest.TestCase):
+class VCRMixin(object):
+    """A TestCase mixin that provides VCR integration."""
     vcr_enabled = True
 
     def setUp(self):
-        super(VCRTestCase, self).setUp()
+        super(VCRMixin, self).setUp()
         if self.vcr_enabled:
             kwargs = self._get_vcr_kwargs()
             myvcr = self._get_vcr(**kwargs)
@@ -37,3 +38,7 @@ class VCRTestCase(unittest.TestCase):
     def _get_cassette_name(self):
         return '{0}.{1}.yaml'.format(self.__class__.__name__,
                                      self._testMethodName)
+
+
+class VCRTestCase(VCRMixin, unittest.TestCase):
+    pass


### PR DESCRIPTION
Trying to introduce VCRTestCase into an existing Django test suite with existing project-specific test cases is not trivial... It requires recreating a lot of Django's test hierarchy just to accommodate VCRTestCase.

Instead I found this solution to be much easier to work with - just add VCRMixin to the test's base classes and it works! Especially easy to work into our setup since the `_get_vcr()` method made it trivial to hook up our existing VCR config. Great work!